### PR TITLE
[IMP] stock: detail in product error

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -385,7 +385,7 @@ class InventoryLine(models.Model):
         if existings:
             raise UserError(_("You cannot have two inventory adjustements in state 'in Progress' with the same product"
                               "(%s), same location(%s), same package, same owner and same lot. Please first validate"
-                              "the first inventory adjustement with this product before creating another one.") % (res.product_id.name, res.location_id.name))
+                              "the first inventory adjustement with this product before creating another one.") % (res.product_id.display_name, res.location_id.name))
         return res
 
     @api.constrains('product_id')


### PR DESCRIPTION
- Create an inventory 1 with "Product A - Variant 1"
- Start inventory
- Create an inventory 2 with "Product A - Variant 1", "product A -
  Variante 2"...
- Start inventory

An error pops-up because two inventories for the same product
"Product A - Variant 1". However, you don't know which variant is
impacted sincethe message error only shows the product name:
"Product A".

Closes #21687
opw-799583

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
